### PR TITLE
[JBIDE-15280] Update parent/pom.xml version to 4.2.0.Alpha1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0.CR1-SNAPSHOT</version>
+		<version>4.2.0.Alpha1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>xulrunner</artifactId>
@@ -16,5 +16,18 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 		<module>features</module>
 		<module>site</module>
 	</modules>
+	<repositories>
+		<!-- To resolve parent artifact -->
+		<repository>
+			<id>jboss-public-repository-group</id>
+			<name>JBoss Public Repository Group</name>
+			<url>http://repository.jboss.org/nexus/content/groups/public/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
 </project>
-	


### PR DESCRIPTION
updated parent pom version and added JBoss Public Group repo
http://repository.jboss.org/nexus/content/groups/public which according to
https://community.jboss.org/wiki/MavenRepository has everything we need to
build module out of the box without modification of ~/.m2/settings.xml

Build seems to be running with brand new local repo configured with
-Dmaven.repo.local=path/to/the/new/repository
